### PR TITLE
Fix batcache ignoring updated version key

### DIFF
--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -552,7 +552,7 @@ $batcache->cache = wp_cache_get($batcache->key, $batcache->group);
 if ( isset( $batcache->cache['version'] ) && $batcache->cache['version'] != $batcache->url_version ) {
 	// Always refresh the cache if a newer version is available.
 	$batcache->do = true;
-} else if ( $batcache->seconds < 1 || $batcache->times < 2 ) {
+} else if ( $batcache->seconds < 1 || $batcache->times < 1 ) {
 	// Are we only caching frequently-requested pages?
 	$batcache->do = true;
 } else {
@@ -570,6 +570,11 @@ if ( isset( $batcache->cache['version'] ) && $batcache->cache['version'] != $bat
 			$batcache->do = false;
 		}
 	}
+}
+
+// Obtain cache generation lock
+if ( $batcache->do ) {
+	$batcache->genlock = wp_cache_add("{$batcache->url_key}_genlock", 1, $batcache->group, 10);
 }
 
 if ( isset( $batcache->cache['time'] ) && // We have cache
@@ -669,11 +674,6 @@ if ( isset( $batcache->cache['time'] ) && // We have cache
 
 	// Have you ever heard a death rattle before?
 	die($batcache->cache['output']);
-}
-
-// Obtain cache generation lock
-if ( $batcache->do ) {
-	$batcache->genlock = wp_cache_add("{$batcache->url_key}_genlock", 1, $batcache->group, 10);
 }
 
 // Didn't meet the minimum condition?


### PR DESCRIPTION
We [changed](https://github.com/humanmade/batcache/commit/916d1b7d08f4df015a14e6087123713d0ededb1c) `$batcache->times` to be 1 instead of 2, but didn't change [the condition](https://github.com/humanmade/batcache/blob/master/advanced-cache.php#L555) that checks the integer, so it always returned true which prevented caches from being served, a [subsequent change](https://github.com/humanmade/batcache/pull/5/commits/3aec51d2166124da70a4ced082e99f501219227d) tried to workaround it but broke the version check logic.

This brings back the regeneration at the original location, and fixes the condition that broke the above.

Refs: 
https://github.com/humanmade/hosting-support/issues/287
https://github.com/humanmade/hm-platform/pull/85