### PR TITLE
Ensure max-age never falls below 0

### DIFF
--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -650,7 +650,7 @@ if ( isset( $batcache->cache['time'] ) && // We have cache
 	// Use the batcache save time for Last-Modified so we can issue "304 Not Modified" but don't clobber a cached Last-Modified header.
 	if ( $batcache->cache_control && !isset($batcache->cache['headers']['Last-Modified'][0]) ) {
 		$max_age = ( $batcache->cache['max_age'] - time() + $batcache->cache['time'] );
-		$max_age = ( $max_age >= $batcache->max_age_stale ) ? $max_age : $batcache->max_age_stale;
+		$max_age = $max_age > 0 ?: $batcache->max_age_stale;
 		header( 'Last-Modified: ' . gmdate( 'D, d M Y H:i:s', $batcache->cache['time'] ) . ' GMT', true );
 		header( 'Cache-Control: max-age=' . $max_age . ', must-revalidate', true );
 	}

--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -42,6 +42,13 @@ class batcache {
 	// This is the base configuration. You can edit these variables or move them into your wp-config.php file.
 	var $max_age =  300; // Expire batcache items aged this many seconds (zero to disable batcache)
 
+	/*
+	 * Used when when an object has expired but hasn't been regenerated. This
+	 * is to relieve load on the origin when stale content is taking a while to
+	 * regenerate.
+	 */
+	var $max_age_stale = 10;
+
 	var $remote  =    0; // Zero disables sending buffers to remote datacenters (req/sec is never sent)
 
 	var $times   =    1; // Only batcache a page after it is accessed this many times... (two or more)
@@ -643,7 +650,7 @@ if ( isset( $batcache->cache['time'] ) && // We have cache
 	// Use the batcache save time for Last-Modified so we can issue "304 Not Modified" but don't clobber a cached Last-Modified header.
 	if ( $batcache->cache_control && !isset($batcache->cache['headers']['Last-Modified'][0]) ) {
 		$max_age = ( $batcache->cache['max_age'] - time() + $batcache->cache['time'] );
-		$max_age = ( $max_age >= 0 ) ? $max_age : 0;
+		$max_age = ( $max_age >= $batcache->max_age_stale ) ? $max_age : $batcache->max_age_stale;
 		header( 'Last-Modified: ' . gmdate( 'D, d M Y H:i:s', $batcache->cache['time'] ) . ' GMT', true );
 		header( 'Cache-Control: max-age=' . $max_age . ', must-revalidate', true );
 	}

--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -642,8 +642,10 @@ if ( isset( $batcache->cache['time'] ) && // We have cache
 
 	// Use the batcache save time for Last-Modified so we can issue "304 Not Modified" but don't clobber a cached Last-Modified header.
 	if ( $batcache->cache_control && !isset($batcache->cache['headers']['Last-Modified'][0]) ) {
+		$max_age = ( $batcache->cache['max_age'] - time() + $batcache->cache['time'] );
+		$max_age = ( $max_age >= 0 ) ? $max_age : 0;
 		header( 'Last-Modified: ' . gmdate( 'D, d M Y H:i:s', $batcache->cache['time'] ) . ' GMT', true );
-		header('Cache-Control: max-age=' . ($batcache->cache['max_age'] - time() + $batcache->cache['time']) . ', must-revalidate', true);
+		header( 'Cache-Control: max-age=' . $max_age . ', must-revalidate', true );
 	}
 
 	// Add some debug info just before </head>


### PR DESCRIPTION
We've found that Batcache can calculate a negative max age, which leads to uncached requests instead of serving stale content (I believe). @joehoyle 	I think you're more familiar with this than I am.

I've identified the location where the negative max-age would be output to be https://github.com/humanmade/altis-cloud/blob/master/dropins/batcache/advanced-cache.php#L646. This is the only location where `Cache-Control: max-age=` could be set to any value that's not a positive integer. `max-age` is also set [here](https://github.com/humanmade/altis-cloud/blob/master/dropins/batcache/advanced-cache.php#L279) , but it's only possible for the value to be positive because the regex only captures digits; the regex won't capture a negative symbol.

My proposed solution would be to set the max-age to `0` if it's a negative value, but I've got a gut feeling that may not be right. Should it actually be `$batcache->maxage`?