### PR TITLE
Fix max_age being set to 1 on Batcache HIT

### DIFF
--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -654,7 +654,7 @@ if ( isset( $batcache->cache['time'] ) && // We have cache
 	// Use the batcache save time for Last-Modified so we can issue "304 Not Modified" but don't clobber a cached Last-Modified header.
 	if ( $batcache->cache_control && !isset($batcache->cache['headers']['Last-Modified'][0]) ) {
 		$max_age = ( $batcache->cache['max_age'] - time() + $batcache->cache['time'] );
-		$max_age = $max_age > 0 ?: $batcache->max_age_stale;
+		$max_age = $max_age > 0 ? $max_age : $batcache->max_age_stale;
 		header( 'Last-Modified: ' . gmdate( 'D, d M Y H:i:s', $batcache->cache['time'] ) . ' GMT', true );
 		header( 'Cache-Control: max-age=' . $max_age . ', must-revalidate', true );
 	}


### PR DESCRIPTION
We had a bug introduced in #10 whereby the `max_age` would always be set to `true` (and then cast to `1`) on Batcache HITs. This was due to a logic error thinking `$max_age > 0 ?:` would evaluate to the value of `$max_age` not a boolean.