### PR TITLE
Add Origin to Vary header

### DIFF
--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -525,7 +525,7 @@ if ( ! method_exists( $GLOBALS['wp_object_cache'], 'incr' ) )
 	$batcache->times = 0;
 
 // Necessary to prevent clients using cached version after login cookies set. If this is a problem, comment it out and remove all Last-Modified headers.
-header('Vary: Cookie', false);
+header('Vary: Cookie, Origin', false);
 
 // Things that define a unique page.
 if ( isset( $_SERVER['QUERY_STRING'] ) ) {


### PR DESCRIPTION
Often the response (mainly the `access-control-allow-origin` header) can vary depending on the value of the `Origin` HTTP header. We need to provide user-agents with this hint, so they don't use a cached response for requests with different Origin headers.