### PR TITLE
Add cache item if it doesnt exist yet

### DIFF
--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -558,6 +558,7 @@ $batcache->generate_keys();
 
 // Get the batcache
 $batcache->cache = wp_cache_get($batcache->key, $batcache->group);
+$is_cached = is_array( $batcache->cache ) && isset( $batcache->cache['time'] );
 
 // Are we only caching frequently-requested pages?
 if ( isset( $batcache->cache['version'] ) && $batcache->cache['version'] != $batcache->url_version ) {

--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -566,20 +566,21 @@ if ( isset( $batcache->cache['version'] ) && $batcache->cache['version'] != $bat
 } else if ( $batcache->seconds < 1 || $batcache->times < 1 ) {
 	// Are we only caching frequently-requested pages?
 	$batcache->do = true;
-} else {
-	// No batcache item found, or ready to sample traffic again at the end of the batcache life?
-	if ( !is_array($batcache->cache) || time() >= $batcache->cache['time'] + $batcache->max_age - $batcache->seconds ) {
-		wp_cache_add($batcache->req_key, 0, $batcache->group);
-		$batcache->requests = wp_cache_incr($batcache->req_key, 1, $batcache->group);
+} else if ( ! is_array( $batcache->cache ) ) {
+	// No batcache item found, create it.
+	$batcache->do = true;
+} else if ( time() >= $batcache->cache['time'] + $batcache->max_age - $batcache->seconds ) {
+	// Ready to sample traffic again at the end of the batcache life?
+	wp_cache_add($batcache->req_key, 0, $batcache->group);
+	$batcache->requests = wp_cache_incr($batcache->req_key, 1, $batcache->group);
 
-		if ( $batcache->requests >= $batcache->times &&
-			time() >= $batcache->cache['time'] + $batcache->cache['max_age']
-		) {
-			wp_cache_delete( $batcache->req_key, $batcache->group );
-			$batcache->do = true;
-		} else {
-			$batcache->do = false;
-		}
+	if ( $batcache->requests >= $batcache->times &&
+		time() >= $batcache->cache['time'] + $batcache->cache['max_age']
+	) {
+		wp_cache_delete( $batcache->req_key, $batcache->group );
+		$batcache->do = true;
+	} else {
+		$batcache->do = false;
 	}
 }
 

--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -568,8 +568,7 @@ if ( isset( $batcache->cache['version'] ) && $batcache->cache['version'] != $bat
 	$batcache->do = true;
 } else if ( ! is_array( $batcache->cache ) ) {
 	// No batcache item found, create it.
-	wp_cache_add( $batcache->req_key, 0, $batcache->group );
-	$batcache->requests = wp_cache_incr( $batcache->req_key, 1, $batcache->group );
+	$batcache->requests = 1;
 	$batcache->do = true;
 } else if ( time() >= $batcache->cache['time'] + $batcache->max_age - $batcache->seconds ) {
 	// Ready to sample traffic again at the end of the batcache life?

--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -558,7 +558,7 @@ $batcache->generate_keys();
 
 // Get the batcache
 $batcache->cache = wp_cache_get($batcache->key, $batcache->group);
-$is_cached = is_array( $batcache->cache ) && isset( $batcache->cache['time'] );
+$is_cached = is_array($batcache->cache) && isset($batcache->cache['time']);
 
 // Are we only caching frequently-requested pages?
 if ( isset( $batcache->cache['version'] ) && $batcache->cache['version'] != $batcache->url_version ) {

--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -576,7 +576,7 @@ if ( isset( $batcache->cache['version'] ) && $batcache->cache['version'] != $bat
 	$batcache->requests = wp_cache_incr($batcache->req_key, 1, $batcache->group);
 
 	if ( $batcache->requests >= $batcache->times &&
-		time() >= $batcache->cache['time'] + $batcache->cache['max_age']
+		( ! $is_cached || time() >= $batcache->cache['time'] + $batcache->cache['max_age'] )
 	) {
 		wp_cache_delete( $batcache->req_key, $batcache->group );
 		$batcache->do = true;

--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -568,6 +568,8 @@ if ( isset( $batcache->cache['version'] ) && $batcache->cache['version'] != $bat
 	$batcache->do = true;
 } else if ( ! is_array( $batcache->cache ) ) {
 	// No batcache item found, create it.
+	wp_cache_add( $batcache->req_key, 0, $batcache->group );
+	$batcache->requests = wp_cache_incr( $batcache->req_key, 1, $batcache->group );
 	$batcache->do = true;
 } else if ( time() >= $batcache->cache['time'] + $batcache->max_age - $batcache->seconds ) {
 	// Ready to sample traffic again at the end of the batcache life?


### PR DESCRIPTION
In some cases `$batcache->cache` is not an array as it doesnt exist yet but it can subsequently be compared as an array throwing a warning. This ensures if the current page isnt in the cache yet it gets added and prevents the warning.