### PR TITLE
Cache redirects when max-age=0

### DIFF
--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -112,6 +112,8 @@ class batcache {
 		if ( $this->cache_redirects ) {
 			$this->redirect_status = $status;
 			$this->redirect_location = $location;
+			header( 'Cache-Control: max-age=' . $this->max_age . ', must-revalidate', true );
+			header_remove( 'Expires' );
 		}
 
 		return $status;
@@ -283,6 +285,7 @@ class batcache {
 					}
 					// If the max-age has been set to zero, but we are caching a redirect, use the default max age.
 					if ( $max_age === 0 && $this->cache_redirects && $this->cache['redirect_location'] ) {
+						header( 'Cache-Control: max-age=' . $this->max_age . ', must-revalidate', true );
 						continue;
 					}
 					$this->max_age = $max_age;
@@ -621,8 +624,15 @@ if ( isset( $batcache->cache['time'] ) && // We have cache
 		$location = $batcache->cache['redirect_location'];
 		// From vars.php
 		$is_IIS = (strpos($_SERVER['SERVER_SOFTWARE'], 'Microsoft-IIS') !== false || strpos($_SERVER['SERVER_SOFTWARE'], 'ExpressionDevServer') !== false);
+		$batcache->do_headers( $batcache->headers, $batcache->cache['headers'] );
+		// Use the batcache save time for Last-Modified so we can issue "304 Not Modified" but don't clobber a cached Last-Modified header.
+		if ( $batcache->cache_control && !isset($batcache->cache['headers']['Last-Modified'][0]) ) {
+			$max_age = ( $batcache->cache['max_age'] - time() + $batcache->cache['time'] );
+			$max_age = $max_age > 0 ? $max_age : $batcache->max_age_stale;
+			header( 'Last-Modified: ' . gmdate( 'D, d M Y H:i:s', $batcache->cache['time'] ) . ' GMT', true );
+			header( 'Cache-Control: max-age=' . $max_age . ', must-revalidate', true );
+		}
 
-		$batcache->do_headers( $batcache->headers );
 		if ( $is_IIS ) {
 			header("Refresh: 0;url=$location");
 		} else {


### PR DESCRIPTION
It's not uncommon that when redirects are sent, the Cache-Control also has `max-age`. This is respected by Batcache, which isn't a great default. Even when `$batcache->cache_redirects` is enabled, the `max-age=0` takes precedence. This PR changes that behaviour to cache redirects regardless of the `max-age=X` in the Cache Control header.