### PR TITLE
Prevent php error by checking for an array first

### DIFF
--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -559,6 +559,7 @@ $batcache->generate_keys();
 
 // Get the batcache
 $batcache->cache = wp_cache_get($batcache->key, $batcache->group);
+$is_cached = is_array($batcache->cache) && isset($batcache->cache['time']);
 
 // Are we only caching frequently-requested pages?
 if ( isset( $batcache->cache['version'] ) && $batcache->cache['version'] != $batcache->url_version ) {
@@ -574,7 +575,7 @@ if ( isset( $batcache->cache['version'] ) && $batcache->cache['version'] != $bat
 		$batcache->requests = wp_cache_incr($batcache->req_key, 1, $batcache->group);
 
 		if ( $batcache->requests >= $batcache->times &&
-			time() >= $batcache->cache['time'] + $batcache->cache['max_age']
+			( ! $is_cached || time() >= $batcache->cache['time'] + $batcache->cache['max_age'] )
 		) {
 			wp_cache_delete( $batcache->req_key, $batcache->group );
 			$batcache->do = true;


### PR DESCRIPTION
In some cases `$batcache->cache` is not an array as it doesn't exist yet but it can subsequently be compared as an array throwing a warning. 

[Original Issue](https://github.com/humanmade/altis-cloud/issues/484) 

Fix implemented from @ntwb's [suggestion](https://github.com/humanmade/batcache/pull/16#issuecomment-898066220). 

Original PR and Link for the fix:  Fixed array offset access on value of type bool with PHP 7.4

This fix supercedes [Pull Request #16 ](https://github.com/humanmade/batcache/pull/16)