### PR TITLE
Require either the 1.x or 2.x branch of composer installers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,6 @@
     "source": "https://github.com/humanmade/batcache"
   },
   "require"    : {
-    "composer/installers": "~1.0"
+    "composer/installers": "^1.0 || ^2.0"
   }
 }


### PR DESCRIPTION
The 1.x requirement is preventing me from upgrading the installers package when also using this package.